### PR TITLE
fix(ci): Publish in the same job to avoid wrong checkouts

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -59,13 +59,6 @@ jobs:
           force: true
           name: "kobyhallx"
 
-  publish-npm:
-    runs-on: ubuntu-22.04
-    needs: update-repository
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,7 @@ on:
     - cron: "0 2 * * *" # run at 2 AM UTC
 
 jobs:
-  update-repository:
+  update-and-publish:
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
I think this is checking out and publishing the wrong commit because it is a separate job. Let's just combine the jobs.