### PR TITLE
Add nightly release at 2 AM UTC

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,6 +6,8 @@ on:
       noir-ref:
         description: The noir reference to checkout
         required: false
+  schedule:
+    - cron: "0 2 * * *" # run at 2 AM UTC
 
 jobs:
   update-and-publish:


### PR DESCRIPTION
# Description

## Problem\*

Adds nightly release to noir_wasm (2 AM UTC time)

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
