### PR TITLE
chore: Switch Github Action to point to master branch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: Build with Nix
         run: |
-          nix build -L github:noir-lang/noir/master/noir-wasm-workflow#wasm
+          nix build -L github:noir-lang/noir/master#wasm
+
 
       - name: Resolve symbolic link
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build with Nix
         run: |
-          nix build -L github:noir-lang/noir/jb/noir-wasm-workflow#wasm
+          nix build -L github:noir-lang/noir/master/noir-wasm-workflow#wasm
 
       - name: Resolve symbolic link
         run: |


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

Accidentally noticed that we were referencing the branch prefixed `jb` -- maybe this is intentional, if so, feel free to close :)

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
