### PR TITLE
Updating dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "module": "./web/noir_wasm.js",
   "sideEffects": false,
   "peerDependencies": {
-    "@noir-lang/noir-source-resolver": "1.1.2"
+    "@noir-lang/noir-source-resolver": "^1.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating so it doesn't in case you need to use `noir-source-resolver` directly (for example on the browser)